### PR TITLE
Sfml fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,9 @@ if(DOWNLOAD_SFML)
 endif()
 
 # Dependencies
-set(SFML_STATIC_LIBRARIES ON CACHE BOOL "" FORCE)
+if(PLATFORM STREQUAL "Windows")
+	set(SFML_STATIC_LIBRARIES ON CACHE BOOL "" FORCE)
+endif()
 find_package(SFML REQUIRED COMPONENTS graphics audio)
 
 # Git operations

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ if(DOWNLOAD_SFML)
 endif()
 
 # Dependencies
+set(SFML_STATIC_LIBRARIES ON CACHE BOOL "" FORCE)
 find_package(SFML REQUIRED COMPONENTS graphics audio)
 
 # Git operations


### PR DESCRIPTION
- Link to SFML statically on Windows (otherwise DLLs are required to be copied to the executable/build directory)
- Link to SFML dynamically on Linux (static libraries are not shipped with releases, need to be built from source)
